### PR TITLE
Add Google Sheets integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+# Google credentials
+*.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# investment
+# Investment Portfolio Tracker
+
+This is a minimal Flask-based web application used to track the state of an investment portfolio. It also supports pulling transaction data from a Google Sheet.
+
+## Getting Started
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Set up Google Sheets credentials (optional):
+   - Create a Google Cloud service account and download the credentials JSON file.
+   - Share your transactions sheet with the service account email.
+   - Set the environment variables `GOOGLE_SERVICE_ACCOUNT_FILE` to the path of the JSON file and `GOOGLE_SHEET_KEY` to your sheet ID.
+
+3. Run the application:
+
+```bash
+python app.py
+```
+
+The server will start on `http://127.0.0.1:5000`.
+Visit `/transactions` to load records from your sheet when configured.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+from portfolio import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,0 +1,26 @@
+import os
+from flask import Flask, jsonify
+
+from .google_sheets import get_transactions
+
+
+def create_app():
+    app = Flask(__name__)
+
+    @app.route('/')
+    def index():
+        return 'Investment Portfolio Tracker'
+
+    @app.route('/transactions')
+    def transactions():
+        sheet_key = os.environ.get('GOOGLE_SHEET_KEY')
+        creds_file = os.environ.get('GOOGLE_SERVICE_ACCOUNT_FILE')
+        if not sheet_key or not creds_file:
+            return 'Google Sheets integration not configured.', 500
+        try:
+            data = get_transactions(sheet_key, creds_file)
+            return jsonify(data)
+        except Exception as exc:
+            return str(exc), 500
+
+    return app

--- a/portfolio/google_sheets.py
+++ b/portfolio/google_sheets.py
@@ -1,0 +1,13 @@
+import gspread
+from google.oauth2.service_account import Credentials
+
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+
+def get_transactions(sheet_key: str, credentials_file: str):
+    """Return all transaction records from the first worksheet."""
+    creds = Credentials.from_service_account_file(credentials_file, scopes=SCOPES)
+    client = gspread.authorize(creds)
+    sheet = client.open_by_key(sheet_key)
+    worksheet = sheet.sheet1
+    return worksheet.get_all_records()

--- a/portfolio/models.py
+++ b/portfolio/models.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Holding:
+    symbol: str
+    shares: float
+    price: float = 0.0
+
+
+@dataclass
+class Portfolio:
+    holdings: List[Holding] = field(default_factory=list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.3
+gspread
+google-auth


### PR DESCRIPTION
## Summary
- connect to Google Sheets using service account
- expose `/transactions` route to show records
- document credentials setup in README
- ignore service account JSON files

## Testing
- `python3 -m py_compile app.py portfolio/__init__.py portfolio/models.py portfolio/google_sheets.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6841f82b74ec832ea9470a9ca694501f