### PR TITLE
Add config file for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ pip install -r requirements.txt
    - Create a Google Cloud service account and download the credentials JSON file.
    - Share your transactions sheet with the service account email.
    - Set the environment variables `GOOGLE_SERVICE_ACCOUNT_FILE` to the path of the JSON file and `GOOGLE_SHEET_KEY` to your sheet ID.
+   - Instead of environment variables you may create a `config.py` file in the project root with `GOOGLE_SHEET_KEY` and `GOOGLE_SERVICE_ACCOUNT_FILE` defined.
 
 3. Run the application:
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,8 @@
+# Configuration file for the investment app.
+# Fill in your Google Sheets credentials here.
+
+# The ID of your Google Sheet.
+GOOGLE_SHEET_KEY = ''
+
+# Path to your Google service account JSON credentials file.
+GOOGLE_SERVICE_ACCOUNT_FILE = ''

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,6 +1,12 @@
 import os
 from flask import Flask, jsonify
 
+try:
+    from config import GOOGLE_SHEET_KEY, GOOGLE_SERVICE_ACCOUNT_FILE
+except Exception:
+    GOOGLE_SHEET_KEY = None
+    GOOGLE_SERVICE_ACCOUNT_FILE = None
+
 from .google_sheets import get_transactions
 
 
@@ -13,8 +19,8 @@ def create_app():
 
     @app.route('/transactions')
     def transactions():
-        sheet_key = os.environ.get('GOOGLE_SHEET_KEY')
-        creds_file = os.environ.get('GOOGLE_SERVICE_ACCOUNT_FILE')
+        sheet_key = os.environ.get('GOOGLE_SHEET_KEY', GOOGLE_SHEET_KEY)
+        creds_file = os.environ.get('GOOGLE_SERVICE_ACCOUNT_FILE', GOOGLE_SERVICE_ACCOUNT_FILE)
         if not sheet_key or not creds_file:
             return 'Google Sheets integration not configured.', 500
         try:


### PR DESCRIPTION
## Summary
- allow specifying credentials in `config.py`
- document the new `config.py` option

## Testing
- `python -m py_compile app.py portfolio/*.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_684295f7ba7c832e948f665e2ada1e82